### PR TITLE
Add Windows service deployment and enhance documentation

### DIFF
--- a/deployment/windows/README_Windows_Service.txt
+++ b/deployment/windows/README_Windows_Service.txt
@@ -1,0 +1,81 @@
+Zabbix Plus Framework - Windows Service Installation Guide
+
+This guide explains how to install, manage, and uninstall the Zabbix Plus Framework as a Windows Service.
+
+Prerequisites:
+1.  Java Installation:
+    *   Ensure that Java Runtime Environment (JRE) or Java Development Kit (JDK) is installed on your system.
+    *   The `java.exe` executable must be available in the system's PATH environment variable, OR
+    *   The `JAVA_HOME` environment variable must be set to point to your Java installation directory.
+        To check, open Command Prompt and type `java -version`. If it runs, Java is likely in your PATH.
+        To set JAVA_HOME (example): `setx JAVA_HOME "C:\Program Files\Java\jdk-11.0.x"` (path may vary).
+
+How to Use `install-service.bat`:
+1.  **Prepare your Application Directory (`APP_ROOT_DIR`):**
+    *   Choose an installation directory for your application (e.g., `C:\ZabbixPlusFramework`). This will be your `APP_ROOT_DIR`.
+    *   Copy your application JAR file (e.g., `core-0.0.1-SNAPSHOT.jar`) into this `APP_ROOT_DIR`.
+    *   Create a `plugins` subdirectory in `APP_ROOT_DIR` and place your plugin JARs into it.
+    *   **Copy Service Scripts:** Copy `zabbix-plus-framework.bat`, `install-service.bat`, and `uninstall-service.bat` from the `deployment/windows` (or wherever you got them) into your `APP_ROOT_DIR`.
+
+2.  Edit `install-service.bat` (now located in your `APP_ROOT_DIR`):
+    *   Open `install-service.bat` in a text editor.
+    *   Set the `SERVICE_NAME` variable if you want a different name for the service (default: "ZabbixPlusFramework").
+    *   Set the `DISPLAY_NAME` variable for a custom display name in the Services console (default: "Zabbix Plus Framework").
+    *   **Crucially, set `APP_ROOT_DIR`** to the absolute path of your application directory (e.g., `C:\ZabbixPlusFramework`).
+    *   Set `LOG_DIR` to the absolute path where you want service logs to be stored (e.g., `C:\ZabbixPlusFramework\logs`). The script will attempt to create this directory if it doesn't exist.
+
+3.  Customize `zabbix-plus-framework.bat` (now located in your `APP_ROOT_DIR`):
+    *   Open `zabbix-plus-framework.bat` in a text editor.
+    *   Update `SET APP_JAR=core-0.0.1-SNAPSHOT.jar` to match the actual filename of your Zabbix Plus Framework JAR file.
+    *   If needed, configure `JAVA_OPTS` by uncommenting the line (`REM SET JAVA_OPTS=...`) and setting appropriate Java Virtual Machine options (e.g., memory settings like `-Xms512m -Xmx1024m`).
+
+4.  Run as Administrator:
+    *   Right-click on `install-service.bat` (the one in your `APP_ROOT_DIR`) and select "Run as administrator".
+    *   Follow any prompts on screen.
+
+How to Use `uninstall-service.bat`:
+1.  Edit `uninstall-service.bat` (if necessary):
+    *   If you changed `SERVICE_NAME` in `install-service.bat`, ensure the `SERVICE_NAME` variable in `uninstall-service.bat` matches.
+2.  Run as Administrator:
+    *   Right-click on `uninstall-service.bat` and select "Run as administrator".
+
+Checking Service Status:
+You can check the status of the service using the Command Prompt:
+`sc query %SERVICE_NAME%`
+(Replace `%SERVICE_NAME%` with the actual service name if you changed it, e.g., `sc query ZabbixPlusFramework`)
+
+Or use the Windows Services management console:
+1.  Press Win + R, type `services.msc`, and press Enter.
+2.  Look for the service by its display name (e.g., "Zabbix Plus Framework").
+
+Service Logs:
+*   Direct log redirection for batch scripts using `sc.exe` is unreliable. The `zabbix-plus-framework.bat` script itself does not currently redirect its output to a file.
+*   The `install-service.bat` script creates a `LOG_DIR` that you specify, but standard output/error from the Java application launched by `zabbix-plus-framework.bat` won't automatically go there.
+*   **Recommended for Robust Logging:** For better log management (capturing stdout/stderr from the Java application to files, log rotation, etc.), it is highly recommended to use a service wrapper utility like NSSM (Non-Sucking Service Manager).
+    *   NSSM allows you to wrap `zabbix-plus-framework.bat` (or directly the `java` command) and provides robust options for I/O redirection.
+    *   NSSM website: https://nssm.cc/
+    *   With NSSM, you would configure it to run `zabbix-plus-framework.bat` and specify output and error log files within the `LOG_DIR`.
+
+Troubleshooting:
+*   "Access Denied" errors: Ensure you are running the `.bat` scripts as an Administrator.
+*   Service fails to start:
+    *   Check `JAVA_HOME` / PATH settings.
+    *   Verify the `APP_JAR` variable in `zabbix-plus-framework.bat` points to the correct JAR file.
+    *   Verify `APP_ROOT_DIR` in `install-service.bat` is correct.
+    *   Check the Windows Event Viewer (Application and System logs) for more detailed error messages.
+    *   Try running `zabbix-plus-framework.bat` directly from a command prompt (as admin) in the `APP_ROOT_DIR` to see if the Java application starts and if there are any console errors.
+NSSM (Non-Sucking Service Manager) - A More Robust Alternative:
+For production environments or where more control over the service is needed (especially for logging, process management, and recovery), using NSSM is strongly recommended.
+
+Key advantages of NSSM:
+*   Reliable stdout and stderr redirection to log files.
+*   Log rotation.
+*   Graceful shutdown of applications.
+*   More advanced recovery options.
+
+You would typically:
+1. Download NSSM.
+2. Run `nssm install <YourServiceName>`
+3. Configure the path to `zabbix-plus-framework.bat` (or directly `java -jar ...`) and set up I/O redirection to your `LOG_DIR`.
+
+This concludes the basic setup for running the Zabbix Plus Framework as a Windows service.

--- a/deployment/windows/install-service.bat
+++ b/deployment/windows/install-service.bat
@@ -1,0 +1,82 @@
+@echo off
+REM Script to install the Zabbix Plus Framework as a Windows Service.
+
+REM --- Configuration ---
+REM !!! IMPORTANT: Edit these variables before running the script !!!
+SET SERVICE_NAME=ZabbixPlusFramework
+SET DISPLAY_NAME="Zabbix Plus Framework"
+REM Set this to the ABSOLUTE path where zabbix-plus-framework.bat and the JAR are located.
+SET APP_ROOT_DIR=C:\path\to\your\application
+REM Set this to the ABSOLUTE path for service logs.
+SET LOG_DIR=C:\path\to\your\application\logs
+REM --- End Configuration ---
+
+echo Installing service %SERVICE_NAME%...
+
+REM Check if running as Administrator
+net session >nul 2>&1
+if %errorLevel% == 0 (
+    echo Administrative permissions confirmed.
+) else (
+    echo ERROR: This script must be run as Administrator.
+    pause
+    exit /b 1
+)
+
+REM Validate APP_ROOT_DIR - check if zabbix-plus-framework.bat exists
+if not exist "%APP_ROOT_DIR%\zabbix-plus-framework.bat" (
+    echo ERROR: zabbix-plus-framework.bat not found in %APP_ROOT_DIR%.
+    echo Please set APP_ROOT_DIR correctly in this script.
+    pause
+    exit /b 1
+)
+
+REM Create log directory if it doesn't exist
+if not exist "%LOG_DIR%" (
+    echo Creating log directory: %LOG_DIR%
+    mkdir "%LOG_DIR%"
+    if errorlevel 1 (
+        echo ERROR: Could not create log directory: %LOG_DIR%.
+        pause
+        exit /b 1
+    )
+)
+
+REM Construct the full path to the batch file
+SET BIN_PATH="%APP_ROOT_DIR%\zabbix-plus-framework.bat"
+
+echo Creating service with binPath: %BIN_PATH%
+sc create %SERVICE_NAME% binPath= "%BIN_PATH%" DisplayName= %DISPLAY_NAME% start= auto obj= LocalSystem
+if errorlevel 1 (
+    echo ERROR: Failed to create service.
+    pause
+    exit /b 1
+)
+
+echo Setting service description...
+sc description %SERVICE_NAME% "Runs the Zabbix Plus Framework application."
+
+echo Configuring service recovery options...
+sc failure %SERVICE_NAME% reset= 86400 actions= restart/60000/restart/60000/restart/60000
+
+echo.
+echo --- Important Notes ---
+echo 1. Ensure Java is installed and 'java.exe' is in your system PATH or JAVA_HOME is set.
+echo 2. Customize 'zabbix-plus-framework.bat' for JAVA_OPTS and the correct JAR file name if needed.
+echo 3. Log redirection for batch file services with 'sc.exe' is limited.
+echo    For robust logging, consider using a service wrapper like NSSM (Non-Sucking Service Manager).
+echo    NSSM can redirect stdout/stderr of your script to files in %LOG_DIR%.
+echo.
+
+REM Attempt to configure basic log redirection (may not work reliably for .bat files)
+REM sc create %SERVICE_NAME% ... other options ... AppExit "cmd.exe /c \"set LOG_FILE=%LOG_DIR%\%SERVICE_NAME%-stdout.log && set ERR_FILE=%LOG_DIR%\%SERVICE_NAME%-stderr.log && %BIN_PATH% >> %LOG_FILE% 2>> %ERR_FILE%\""
+REM The above is complex and often fails. We will rely on users using NSSM or similar for proper logging for now.
+
+echo To start the service, run:
+echo sc start %SERVICE_NAME%
+echo or use the Services management console (services.msc).
+
+echo.
+echo Service %SERVICE_NAME% installed successfully.
+pause
+exit /b 0

--- a/deployment/windows/uninstall-service.bat
+++ b/deployment/windows/uninstall-service.bat
@@ -1,0 +1,35 @@
+@echo off
+REM Script to uninstall the Zabbix Plus Framework Windows Service.
+
+REM --- Configuration ---
+REM !!! IMPORTANT: Edit this variable if you changed it during installation !!!
+SET SERVICE_NAME=ZabbixPlusFramework
+REM --- End Configuration ---
+
+echo Uninstalling service %SERVICE_NAME%...
+
+REM Check if running as Administrator
+net session >nul 2>&1
+if %errorLevel% == 0 (
+    echo Administrative permissions confirmed.
+) else (
+    echo ERROR: This script must be run as Administrator.
+    pause
+    exit /b 1
+)
+
+echo Stopping service %SERVICE_NAME%...
+sc stop %SERVICE_NAME%
+REM It's okay if stop fails (e.g., service not running), so we don't check errorlevel here rigorously.
+
+echo Deleting service %SERVICE_NAME%...
+sc delete %SERVICE_NAME%
+if errorlevel 1 (
+    echo ERROR: Failed to delete service. It might not exist or other issues occurred.
+    pause
+    exit /b 1
+)
+
+echo Service %SERVICE_NAME% uninstalled successfully.
+pause
+exit /b 0

--- a/deployment/windows/zabbix-plus-framework.bat
+++ b/deployment/windows/zabbix-plus-framework.bat
@@ -1,0 +1,21 @@
+@echo off
+echo Starting application...
+
+REM Placeholder for JAVA_OPTS. User should configure this as needed.
+REM SET JAVA_OPTS=-Xms256m -Xmx512m
+
+REM Placeholder for the application JAR path. User should configure this.
+SET APP_JAR=core-0.0.1-SNAPSHOT.jar
+
+REM Navigate to the application's root directory.
+REM This script assumes it is located in the application's root directory.
+cd /d "%~dp0"
+
+REM Execute the Java application.
+java %JAVA_OPTS% -jar %APP_JAR%
+
+REM Basic error handling.
+if errorlevel 1 (
+    echo Application failed to start.
+    pause
+)


### PR DESCRIPTION
This commit introduces scripts and instructions for deploying the Zabbix Plus Framework as a Windows service using sc.exe. It also provides guidance on using NSSM as a more robust alternative.

Key changes:
- Added `install-service.bat`, `uninstall-service.bat`, and `zabbix-plus-framework.bat` to the `deployment/windows` directory.
- Included `README_Windows_Service.txt` with detailed instructions for Windows service setup.
- Overhauled the "Packaging and Deployment" section in the main `README.md`.
- Provided detailed instructions for packaging the application and deploying it as a service on Windows, Linux (systemd), and macOS (launchd).
- Included sample startup scripts (`.sh`) for Linux and macOS.
- Reorganized and renumbered `README.md` sections for better clarity and flow.
- Ensured existing `systemd` and `launchd` files are consistent with the new documentation.